### PR TITLE
feat(splashscreen): Add support for spinner on Android and iOS (#1653)

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -2,45 +2,50 @@ import Foundation
 import AudioToolbox
 
 @objc(CAPSplashScreenPlugin)
-public class CAPSplashScreenPlugin : CAPPlugin {
+public class CAPSplashScreenPlugin: CAPPlugin {
   var imageView = UIImageView()
   var image: UIImage?
+  var spinner = UIActivityIndicatorView()
+  var showSpinner: Bool = false
   var call: CAPPluginCall?
   var hideTask: Any?
   var isVisible: Bool = false
-  
+
   let launchShowDuration = 3000
   let launchAutoHide = true
-  
+
   let defaultFadeInDuration = 200
   let defaultFadeOutDuration = 200
   let defaultShowDuration = 3000
   let defaultAutoHide = true
-  
+
   public override func load() {
     buildViews()
     showOnLaunch()
   }
-  
+
   // Show the splash screen
   @objc public func show(_ call: CAPPluginCall) {
     self.call = call
-    
+
     if image == nil {
       call.error("No image named \"Splash\" found. Please check your Assets.xcassets for a file named Splash")
       return
     }
-    
+
     let showDuration = call.get("showDuration", Int.self, defaultShowDuration)!
     let fadeInDuration = call.get("fadeInDuration", Int.self, defaultFadeInDuration)!
     let fadeOutDuration = call.get("fadeOutDuration", Int.self, defaultFadeOutDuration)!
     let autoHide = call.get("autoHide", Bool.self, defaultAutoHide)!
-    
-    showSplash(showDuration: showDuration, fadeInDuration: fadeInDuration, fadeOutDuration: fadeOutDuration, autoHide: autoHide, completion: {
-      call.success()
-    }, isLaunchSplash: false)
+    let spinnerStyle = getConfigValue("iosSpinnerStyle") as? String ?? nil
+    let spinnerColor = getConfigValue("spinnerColor") as? String ?? nil
+    showSpinner = getConfigValue("showSpinner") as? Bool ?? false
+
+    showSplash(showDuration: showDuration, fadeInDuration: fadeInDuration, fadeOutDuration: fadeOutDuration, autoHide: autoHide, spinnerStyle: spinnerStyle, spinnerColor: spinnerColor, completion: {
+        call.success()
+      }, isLaunchSplash: false)
   }
-  
+
   // Hide the splash screen
   @objc public func hide(_ call: CAPPluginCall) {
     self.call = call
@@ -48,30 +53,41 @@ public class CAPSplashScreenPlugin : CAPPlugin {
     hideSplash(fadeOutDuration: fadeDuration)
     call.success()
   }
-  
+
   func buildViews() {
     // Find the image asset named "Splash"
     // TODO: Find a way to not hard code this?
-    image = UIImage.init(named: "Splash")
-    
+    image = UIImage(named: "Splash")
+
     if image == nil {
-      print("Unable to find splash screen image. Make sure an image called Splash exists in your assets")
+      print(
+        "Unable to find splash screen image. Make sure an image called Splash exists in your assets"
+      )
     }
-    
-    // Observe for changes on fram and bounds to handle rotation resizing
-    let parentView = self.bridge.viewController.view
+
+    // Observe for changes on frame and bounds to handle rotation resizing
+    let parentView = bridge.viewController.view
     parentView?.addObserver(self, forKeyPath: "frame", options: .new, context: nil)
     parentView?.addObserver(self, forKeyPath: "bounds", options: .new, context: nil)
-    
-    self.updateSplashImageBounds()
+
+    updateSplashImageBounds()
+    showSpinner = getConfigValue("showSpinner") as? Bool ?? false
+    if showSpinner {
+      spinner.translatesAutoresizingMaskIntoConstraints = false
+      spinner.startAnimating()
+    }
   }
-  
+
   func tearDown() {
-    self.isVisible = false
+    isVisible = false
     bridge.viewController.view.isUserInteractionEnabled = true
-    self.imageView.removeFromSuperview()
+    imageView.removeFromSuperview()
+
+    if showSpinner {
+      spinner.removeFromSuperview()
+    }
   }
-  
+
   // Update the bounds for the splash image. This will also be called when
   // the parent view observers fire
   func updateSplashImageBounds() {
@@ -85,65 +101,107 @@ public class CAPSplashScreenPlugin : CAPPlugin {
       return
     }
     imageView.image = image
-    imageView.frame = CGRect.init(origin: CGPoint.init(x: 0, y: 0), size: window.bounds.size)
+    imageView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: window.bounds.size)
     imageView.contentMode = .scaleAspectFill
   }
-  
-  public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+
+  public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change _: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
     updateSplashImageBounds()
   }
-  
+
   func showOnLaunch() {
-    self.bridge.viewController.view.addSubview(self.imageView)
     let launchShowDurationConfig = getConfigValue("launchShowDuration") as? Int ?? launchShowDuration
     let launchAutoHideConfig = getConfigValue("launchAutoHide") as? Bool ?? launchAutoHide
-    showSplash(showDuration: launchShowDurationConfig, fadeInDuration: 0, fadeOutDuration: defaultFadeOutDuration, autoHide: launchAutoHideConfig, completion: {
+    let launchSpinnerStyleConfig = getConfigValue("iosSpinnerStyle") as? String ?? nil
+    let launchSpinnerColorConfig = getConfigValue("spinnerColor") as? String ?? nil
+    print("valor de showSpinner\(showSpinner)")
+
+    let view = bridge.viewController.view
+    view?.addSubview(imageView)
+
+    if showSpinner {
+      view?.addSubview(spinner)
+      spinner.centerXAnchor.constraint(equalTo: view!.centerXAnchor).isActive = true
+      spinner.centerYAnchor.constraint(equalTo: view!.centerYAnchor).isActive = true
+    }
+
+    showSplash(showDuration: launchShowDurationConfig, fadeInDuration: 0, fadeOutDuration: defaultFadeOutDuration, autoHide: launchAutoHideConfig, spinnerStyle: launchSpinnerStyleConfig, spinnerColor: launchSpinnerColorConfig, completion: {
     }, isLaunchSplash: true)
   }
-  
-  func showSplash(showDuration: Int, fadeInDuration: Int, fadeOutDuration: Int, autoHide: Bool, completion: @escaping () -> Void, isLaunchSplash: Bool) {
-    
+
+  func showSplash(showDuration: Int, fadeInDuration: Int, fadeOutDuration: Int, autoHide: Bool, spinnerStyle: String?, spinnerColor: String?, completion: @escaping () -> Void, isLaunchSplash: Bool) {
     DispatchQueue.main.async {
-      
-      if !isLaunchSplash {
-        self.bridge.viewController.view.addSubview(self.imageView)
+      let view = self.bridge.viewController.view
+
+      if self.showSpinner {
+        if spinnerStyle != nil {
+          switch spinnerStyle!.lowercased() {
+          case "small":
+            self.spinner.style = .white
+          default:
+            self.spinner.style = .whiteLarge
+          }
+        }
+
+        if spinnerColor != nil {
+          self.spinner.color = UIColor(fromHex: spinnerColor!)
+        }
       }
 
-      self.bridge.viewController.view.isUserInteractionEnabled = false
+      if !isLaunchSplash {
+        view?.addSubview(self.imageView)
+
+        if self.showSpinner {
+          view?.addSubview(self.spinner)
+          self.spinner.centerXAnchor.constraint(equalTo: view!.centerXAnchor).isActive = true
+          self.spinner.centerYAnchor.constraint(equalTo: view!.centerYAnchor).isActive = true
+        }
+      }
+
+      view?.isUserInteractionEnabled = false
 
       UIView.transition(with: self.imageView, duration: TimeInterval(Double(fadeInDuration) / 1000), options: .curveLinear, animations: {
-        self.imageView.alpha = 1
-      }) { (finished: Bool) in
+          self.imageView.alpha = 1
+
+          if self.showSpinner {
+            self.spinner.alpha = 1
+          }
+        }) { (finished: Bool) in
         self.isVisible = true
 
         if autoHide {
-          self.hideTask = DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + (Double(showDuration) / 1000), execute: {
+          self.hideTask = DispatchQueue.main.asyncAfter(
+            deadline: DispatchTime.now() + (Double(showDuration) / 1000)
+          ) {
             self.hideSplash(fadeOutDuration: fadeOutDuration, isLaunchSplash: isLaunchSplash)
             completion()
-          })
+          }
         }
       }
     }
   }
 
   func hideSplash(fadeOutDuration: Int) {
-    self.hideSplash(fadeOutDuration: fadeOutDuration, isLaunchSplash: false);
+    hideSplash(fadeOutDuration: fadeOutDuration, isLaunchSplash: false)
   }
-  
+
   func hideSplash(fadeOutDuration: Int, isLaunchSplash: Bool) {
-    if(isLaunchSplash && isVisible) {
+    if isLaunchSplash, isVisible {
       print("SplashScreen.hideSplash: SplashScreen was automatically hidden after default timeout. " +
             "You should call `SplashScreen.hide()` as soon as your web app is loaded (or increase the timeout). " +
-            "Read more at https://capacitor.ionicframework.com/docs/apis/splash-screen/#hiding-the-splash-screen");
+            "Read more at https://capacitor.ionicframework.com/docs/apis/splash-screen/#hiding-the-splash-screen")
     }
     if !isVisible { return }
     DispatchQueue.main.async {
       UIView.transition(with: self.imageView, duration: TimeInterval(Double(fadeOutDuration) / 1000), options: .curveLinear, animations: {
-        self.imageView.alpha = 0
-      }) { (finished: Bool) in
+          self.imageView.alpha = 0
+
+          if self.showSpinner {
+            self.spinner.alpha = 0
+          }
+        }) { (finished: Bool) in
         self.tearDown()
       }
     }
   }
 }
-

--- a/ios/Capacitor/Capacitor/UIColor.swift
+++ b/ios/Capacitor/Capacitor/UIColor.swift
@@ -1,19 +1,52 @@
 extension UIColor {
-  convenience init(fromHex hex: String) {
-    var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-    
-    if (cString.hasPrefix("#")) {
-      cString.remove(at: cString.startIndex)
+  convenience init(r: Int, g: Int, b: Int, a: Int = 0xFF) {
+    self.init(
+      red: CGFloat(r) / 255.0,
+      green: CGFloat(g) / 255.0,
+      blue: CGFloat(b) / 255.0,
+      alpha: CGFloat(a) / 255.0
+    )
+  }
+
+  convenience init(argb: UInt32) {
+    self.init(
+      red: CGFloat((argb >> 16) & 0xFF),
+      green: CGFloat((argb >> 8) & 0xFF),
+      blue: CGFloat(argb & 0xFF),
+      alpha: CGFloat((argb >> 24) & 0xFF)
+    )
+  }
+
+  convenience init?(fromHex: String) {
+    let hexString = fromHex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(
+      of: "#",
+      with: ""
+    )
+
+    var argb: UInt32 = 0
+
+    var r: CGFloat = 0.0
+    var g: CGFloat = 0.0
+    var b: CGFloat = 0.0
+    var a: CGFloat = 1.0
+
+    guard Scanner(string: hexString).scanHexInt32(&argb) else { return nil }
+
+    if hexString.count == 6 {
+      r = CGFloat((argb & 0xFF0000) >> 16) / 255.0
+      g = CGFloat((argb & 0x00FF00) >> 8) / 255.0
+      b = CGFloat(argb & 0x0000FF) / 255.0
+
+    } else if hexString.count == 8 {
+      r = CGFloat((argb & 0xFF00_0000) >> 24) / 255.0
+      g = CGFloat((argb & 0x00FF0000) >> 16) / 255.0
+      b = CGFloat((argb & 0x0000FF00) >> 8) / 255.0
+      a = CGFloat(argb & 0x000000FF) / 255.0
+
+    } else {
+      return nil
     }
 
-    var rgbValue:UInt32 = 0
-    Scanner(string: cString).scanHexInt32(&rgbValue)
-    
-    self.init(
-      red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
-      green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
-      blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
-      alpha: CGFloat(1.0)
-    )
+    self.init(red: r, green: g, blue: b, alpha: a)
   }
 }

--- a/site/docs-md/apis/splash-screen/index.md
+++ b/site/docs-md/apis/splash-screen/index.md
@@ -5,6 +5,7 @@ url: /docs/apis/splash-screen
 contributors:
   - mlynch
   - jcesarmobile
+  - trancee
 ---
 
 <plugin-platforms platforms="pwa,ios,android,electron"></plugin-platforms>
@@ -69,6 +70,38 @@ If you want to be sure the splash never hides before the app is fully loaded, se
 
 Then run `npx cap copy` to apply these changes.
 
+## Spinner
+
+If you want to show a spinner on top of the splash screen, set `showSpinner` to `true` in your `capacitor.config.json`:
+
+```json
+{
+  "plugins": {
+    "SplashScreen": {
+      "showSpinner": true
+    }
+  }
+}
+```
+
+You can customize the appearance of the spinner with the following configuration.
+
+For Android, `androidSpinnerStyle` has the following options:
+- horizontal
+- small
+- large (default)
+- inverse
+- smallInverse
+- largeInverse
+
+For iOS, `iosSpinnerStyle` has the following options:
+- large (default)
+- small 
+
+To set the color of the spinner use `spinnerColor`, values are either `#RGB` or `#ARGB`.
+
+Then run `npx cap copy` to apply these changes.
+
 ## Configuration
 
 These config parameters are available in `capacitor.config.json`:
@@ -79,6 +112,10 @@ These config parameters are available in `capacitor.config.json`:
     "SplashScreen": {
       "launchShowDuration": 3000,
       "launchAutoHide": true,
+      "androidSpinnerStyle": "large",
+      "iosSpinnerStyle": "small",
+      "spinnerColor": "#999999",
+      "showSpinner": true,
       "androidSplashResourceName": "splash",
       "androidScaleType": "CENTER_CROP"
     }


### PR DESCRIPTION
* Added androidBackgroundColor to Splash Screen plugin.

* Added spinner for iOS splash screen.

* Added support for spinner on Splash Screen.

* Added support for spinner on Splash Screen for Android.

* Fixed some strange code formatting.

* Added support for iOS spinner.

* Moved UIColor extension to proper place and use different code formatter.

* Added platform specific spinnerStyle and removed launch configuration.

* Added documentation for spinner.

* Fixed issue with string comparison.

* Simplify iOS styles fix some errors and change code format